### PR TITLE
Remove turbolink cache so going back doesn't break layouts

### DIFF
--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -11,13 +11,15 @@
 // GO AFTER THE REQUIRES BELOW.
 //= require_tree ./libs
 //= require_tree ./plugins
+//= require turbolinks
 //= require_tree ./mixins
 //= require ./controllers/AppController.js
 //= require_tree ./controllers
 //= require_self
 //= require jquery_ujs
-//= require turbolinks
 //= require ./draft_cropping.js.coffee
+
+Turbolinks.pagesCached(0);
 
 appController = new AppController();
 $(document).on('page:change', function(){


### PR DESCRIPTION
I thought this would require more work hence the plural in the branch name. 
